### PR TITLE
Evaluate size and domain dynamically to resolve #11

### DIFF
--- a/nurbs.js
+++ b/nurbs.js
@@ -261,7 +261,7 @@ function domainGetter () {
   var ret = [];
 
   // If the reference to size is hard-coded, then the size cannot change, or
-  // if you change points manuall (like by appending a point) without re-running
+  // if you change points manually (like by appending a point) without re-running
   // the constructor, then it'll be incorrect. This aims for middle-ground
   // by querying the size directly, based on the point data type
   //

--- a/nurbs.js
+++ b/nurbs.js
@@ -3,6 +3,7 @@
 var inferType = require('./src/utils/infer-type');
 var computeCacheKey = require('./src/utils/cache-key');
 var isNdarray = require('./src/utils/is-ndarray');
+var isNdarrayLike = require('./src/utils/is-ndarray-like');
 var createAccessors = require('./src/utils/create-accessors');
 var numericalDerivative = require('./src/numerical-derivative');
 var isArrayLike = require('./src/utils/is-array-like');
@@ -69,8 +70,12 @@ function parseNURBS (points, degree, knots, weights, boundary, opts) {
             configurable: true
           },
           size: {
-            value: this.points.shape.slice(0, this.points.shape.length - 1),
-            writable: false,
+            get: function () {
+              return this.points.shape.slice(0, this.points.shape.length - 1);
+            },
+            set: function () {
+              throw new Error("Cannot assign to read only property 'size'");
+            },
             configurable: true
           }
         });
@@ -101,8 +106,17 @@ function parseNURBS (points, degree, knots, weights, boundary, opts) {
             configurable: true
           },
           size: {
-            value: size,
-            writable: false,
+            get: function () {
+              var size = [];
+              size.length = 0;
+              for (var i = 0, ptr = this.points; i < this.splineDimension; i++, ptr = ptr[0]) {
+                size[i] = ptr.length;
+              }
+              return size;
+            },
+            set: function () {
+              throw new Error("Cannot assign to read only property 'size'");
+            },
             configurable: true
           }
         });
@@ -235,14 +249,6 @@ function parseNURBS (points, degree, knots, weights, boundary, opts) {
     this.evaluator = function (derivativeOrder, isBasis) {
       return createEvaluator(this.__cacheKey, this, accessors, this.debug, this.checkBounds, isBasis, derivativeOrder);
     };
-
-    this.basisEvaluator = function () {
-      return createEvaluator(this.__cacheKey, this, accessors, this.debug, this.checkBounds, true);
-    };
-
-    this.derivativeEvaluator = function (orderPerDimension) {
-      return createEvaluator(this.__cacheKey, this, accessors, this.debug, this.checkBounds, false, orderPerDimension);
-    };
   }
 
   this.numericalDerivative = numericalDerivative.bind(this);
@@ -251,16 +257,40 @@ function parseNURBS (points, degree, knots, weights, boundary, opts) {
 }
 
 function domainGetter () {
+  var sizeArray;
   var ret = [];
+
+  // If the reference to size is hard-coded, then the size cannot change, or
+  // if you change points manuall (like by appending a point) without re-running
+  // the constructor, then it'll be incorrect. This aims for middle-ground
+  // by querying the size directly, based on the point data type
+  //
+  // A pointer to the point array-of-arrays:
+  var ptr = this.points;
+
+  if (!ptr) {
+    // If there are no points, then just use this.size
+    sizeArray = this.size;
+  } else if (isNdarrayLike(ptr)) {
+    // If it's an ndarray, use the ndarray's shape property
+    sizeArray = ptr.shape;
+  }
+
   for (var d = 0; d < this.splineDimension; d++) {
+    var size = sizeArray ? sizeArray[d] : ptr.length;
     var p = this.degree[d];
     var isClosed = this.boundary[d] === 'closed';
+
     if (this.knots && this.knots[d]) {
       var k = this.knots[d];
-      ret[d] = [k[isClosed ? 0 : p], k[this.size[d]]];
+      ret[d] = [k[isClosed ? 0 : p], k[size]];
     } else {
-      ret[d] = [isClosed ? 0 : p, this.size[d]];
+      ret[d] = [isClosed ? 0 : p, size];
     }
+
+    // Otherwise if it's an array of arrays, we get the size of the next
+    // dimension by recursing into the points
+    if (ptr) ptr = ptr[0];
   }
   return ret;
 }
@@ -283,7 +313,9 @@ function nurbs (points, degree, knots, weights, boundary, opts) {
     get: domainGetter
   });
 
-  return parseFcn(points, degree, knots, weights, boundary, opts);
+  parseFcn(points, degree, knots, weights, boundary, opts);
+
+  return ctor;
 }
 
 module.exports = nurbs;

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -7,6 +7,7 @@ var variable = require('./utils/variable');
 var accessorPreamble = require('./utils/accessor-preamble');
 var inferType = require('./utils/infer-type');
 var isArrayLike = require('./utils/is-array-like');
+var sizeGetter = require('./utils/size-getter');
 
 var evaluatorCache = {};
 var codeCache = {};
@@ -134,7 +135,7 @@ module.exports = function (cacheKey, nurbs, accessors, debug, checkBounds, isBas
   }
 
   for (d = 0; d < splineDimension; d++) {
-    line('var ' + sizeVar(d) + ' = this.size[' + d + '];');
+    line('var ' + sizeVar(d) + ' = ' + sizeGetter(points, 'this.points', d) + ';');
   }
   code.push(accessorPreamble(nurbs, 'x', 'this.points', points));
 

--- a/src/support.js
+++ b/src/support.js
@@ -7,6 +7,7 @@ var variable = require('./utils/variable');
 var accessorPreamble = require('./utils/accessor-preamble');
 var inferType = require('./utils/infer-type');
 var isArrayLike = require('./utils/is-array-like');
+var sizeGetter = require('./utils/size-getter');
 
 var supportCache = {};
 
@@ -74,7 +75,7 @@ module.exports = function (cacheKey, nurbs, accessors, debug, checkBounds) {
   }
 
   for (d = 0; d < splineDimension; d++) {
-    line('var ' + sizeVar(d) + ' = this.size[' + d + '];');
+    line('var ' + sizeVar(d) + ' = ' + sizeGetter(nurbs.points, 'this.points', d) + ';');
   }
 
   if (!allDimensionUniform) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -4,6 +4,8 @@
 
 var transformerCache = {};
 var accessorPreamble = require('./utils/accessor-preamble');
+var sizeGetter = require('./utils/size-getter');
+var variable = require('./utils/variable');
 
 module.exports = function createTransform (cacheKey, nurbs, accessors, debug) {
   var i, j, iterator, iterators, terms, n, rvalue, lvalue;
@@ -19,11 +21,16 @@ module.exports = function createTransform (cacheKey, nurbs, accessors, debug) {
   code.push('var i, w;');
   code.push(accessorPreamble(nurbs, 'x', 'this.points', nurbs.points));
 
+  var sizeVar = variable(debug ? 'size' : 's');
+  for (i = 0; i < nurbs.splineDimension; i++) {
+    code.push('var ' + sizeVar(i) + ' = ' + sizeGetter(nurbs.points, 'this.points', i) + ';');
+  }
+
   iterators = [];
   for (i = 0; i < nurbs.splineDimension; i++) {
     iterator = 'i' + i;
     iterators.push(iterator);
-    code.push('for (' + iterator + ' = this.size[' + i + '] - 1; ' + iterator + ' >= 0; ' + iterator + '--) {');
+    code.push('for (' + iterator + ' = ' + sizeVar(i) + '- 1; ' + iterator + ' >= 0; ' + iterator + '--) {');
   }
 
   for (i = 0; i < nurbs.dimension; i++) {

--- a/src/utils/size-getter.js
+++ b/src/utils/size-getter.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var isNdarrayLike = require('./is-ndarray-like');
+
+module.exports = function (data, dataVariableName, dimension) {
+  if (!data) {
+    return 'this.size[' + dimension + ']';
+  } else if (isNdarrayLike(data)) {
+    return dataVariableName + '.shape[' + dimension + ']';
+  } else {
+    var str = dataVariableName;
+    for (var i = 0; i < dimension; i++) {
+      str += '[0]';
+    }
+    return str + '.length';
+  }
+};

--- a/test/array-of-arrays.js
+++ b/test/array-of-arrays.js
@@ -357,6 +357,31 @@ test('array-of-array style nurbs', function (t) {
       }, /Expected an array of points/);
       t.end();
     });
+
+    t.test('does not require updating to change the number of points', function (t) {
+      var spline = nurbs({points: [[1], [2]], checkBounds: true});
+      t.deepEqual(spline.evaluate([], 1.5), [1.5]);
+      spline.points = [[1], [2], [3], [4], [5]];
+      t.deepEqual(spline.evaluate([], 4.5), [4.5]);
+
+      t.end();
+    });
+
+    t.test('evaluates size dynamically', function (t) {
+      var spline = nurbs([[1], [2], [3]]);
+      t.deepEqual(spline.size, [3]);
+      spline.points.push([5]);
+      t.deepEqual(spline.size, [4]);
+      t.end();
+    });
+
+    t.test('evaluates the domain dynamically', function (t) {
+      var spline = nurbs([[1], [2], [3]]);
+      t.deepEqual(spline.domain, [[2, 3]]);
+      spline.points.push([5]);
+      t.deepEqual(spline.domain, [[2, 4]]);
+      t.end();
+    });
   });
 
   t.test('evaluation', function (t) {
@@ -889,7 +914,7 @@ test('array-of-array style nurbs', function (t) {
         boundary: 'clamped'
       });
 
-      var basis = spline.basisEvaluator();
+      var basis = spline.evaluator(null, true);
       t.equal(basis(2, 0), 1);
       t.equal(basis(2, 1), 0);
       t.equal(basis(2, 2), 0);
@@ -916,7 +941,7 @@ test('array-of-array style nurbs', function (t) {
         boundary: 'clamped'
       });
 
-      var basis = spline.basisEvaluator();
+      var basis = spline.evaluator(null, true);
 
       t.equal(basis(3.5, 3.5, 0, 0), 0.015625);
       t.equal(basis(3.5, 3.5, 1, 0), 0.046875);
@@ -977,7 +1002,7 @@ test('array-of-array style nurbs', function (t) {
 
     t.test('allows basis function evaluation without points', function (t) {
       var curve = nurbs({size: 10});
-      var basis = curve.basisEvaluator();
+      var basis = curve.evaluator(null, true);
       t.equal(basis(3, 0), 0.0);
       t.equal(basis(3, 1), 0.5);
       t.equal(basis(3, 2), 0.5);

--- a/test/derivative.js
+++ b/test/derivative.js
@@ -12,7 +12,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 2
       });
 
-      var der1 = spline.derivativeEvaluator(1);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -35,7 +35,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 2
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -59,7 +59,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 2
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -83,7 +83,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 2
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -106,7 +106,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 3
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -130,7 +130,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 3
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -154,7 +154,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 3
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -179,7 +179,7 @@ test('array-of-array style nurbs', function (t) {
         degree: 2
       });
 
-      var der1 = spline.derivativeEvaluator([1]);
+      var der1 = spline.evaluator([1]);
       var domain = spline.domain[0];
       var n = 11;
 
@@ -206,7 +206,7 @@ test('array-of-array style nurbs', function (t) {
         ],
         degree: 2
       });
-      var der1 = spline.derivativeEvaluator([1, 0]);
+      var der1 = spline.evaluator([1, 0]);
       var domain = spline.domain;
       var n = 5;
 
@@ -235,7 +235,7 @@ test('array-of-array style nurbs', function (t) {
         ],
         degree: 2
       });
-      var der1 = spline.derivativeEvaluator([0, 1]);
+      var der1 = spline.evaluator([0, 1]);
       var domain = spline.domain;
       var n = 5;
 

--- a/test/ndarray.js
+++ b/test/ndarray.js
@@ -35,6 +35,24 @@ test('ndarray style nurbs', function (t) {
     });
   });
 
+  t.test('update', function (t) {
+    t.test('evaluates size dynamically', function (t) {
+      var spline = nurbs(pack([[1], [2], [3]]));
+      t.deepEqual(spline.size, [3]);
+      spline.points = pack([[1], [2], [3], [4]]);
+      t.deepEqual(spline.size, [4]);
+      t.end();
+    });
+
+    t.test('evaluates the domain dynamically', function (t) {
+      var spline = nurbs(pack([[1], [2], [3]]));
+      t.deepEqual(spline.domain, [[2, 3]]);
+      spline.points = pack([[1], [2], [3], [4]]);
+      t.deepEqual(spline.domain, [[2, 4]]);
+      t.end();
+    });
+  });
+
   t.test('evaluation', function (t) {
     t.test('curves', function (t) {
       t.test('evaluates correctly for a uniform quadratic b-spline', function (t) {


### PR DESCRIPTION
This PR modifies size and domain to make them dynamic in the sense that 1) you can't overwrite them nonsensically, and 2) you can modify `points` directly and expect evaluation to be correct.

It does this by assigning getters or read-only properties (i.e. when it's just a number) and by trivially building size evaluation into the evaluation itself rather than using the initially computed size value.

/cc @twolfson for awareness, but no review necessary unless desired. FWIW this moves it much closer to what I'd consider publishable. This was one of the big API inconsistencies that was bothering me.